### PR TITLE
OPHJOD-1239: Use adaptive media image path with MediaCards

### DIFF
--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -1,5 +1,5 @@
 import { LoaderData } from '@/routes/Home/loader';
-import { findContentValueByName } from '@/utils/cms';
+import { findContentValueByName, getAdaptiveMediaSrc } from '@/utils/cms';
 import { CardCarousel, CardCarouselItem, HeroCard, MediaCard, useMediaQueries } from '@jod/design-system';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -69,6 +69,7 @@ const Home = () => {
       const imageContent = findContentValueByName(item, 'image')?.image;
       const ingress = findContentValueByName(item, 'ingress')?.data;
       const id = `${item.id ?? ''}`;
+      const imageSrc = getAdaptiveMediaSrc(imageContent?.id, imageContent?.title, 'thumbnail');
 
       return {
         id,
@@ -76,7 +77,7 @@ const Home = () => {
           <MediaCard
             label={item.title ?? ''}
             description={ingress ?? ''}
-            imageSrc={imageContent?.contentUrl ?? ''}
+            imageSrc={imageSrc}
             imageAlt={imageContent?.title ?? ''}
             to={`/${language}/${t('slugs.content-details')}/${id}`}
             linkComponent={Link}

--- a/src/utils/cms.ts
+++ b/src/utils/cms.ts
@@ -2,6 +2,10 @@ import { LangCode } from '@/i18n/config';
 import { StructuredContent } from '@/types/cms-content';
 
 type ContentName = 'ingress' | 'content' | 'image' | 'document' | 'link';
+const AdaptiveMediaSizes = {
+  thumbnail: 'Thumbnail-300x300',
+  preview: 'Preview-1000x0',
+};
 
 /**
  * Finds the content value from Liferay strucured content by label
@@ -28,4 +32,25 @@ export const getAcceptLanguageHeader = (language: LangCode) => {
   }
 
   return { 'Accept-Language': resourceLangCode };
+};
+
+/**
+ * Generates the URL for an adaptive media image in Liferay.
+ *
+ * @param fileId - The ID of the Liferay image file entry.
+ * @param fileName - The name of the file.
+ * @param size - The desired image size, as a key of AdaptiveMediaSizes.
+ * @returns The adaptive media image URL or an empty string if inputs are invalid.
+ */
+export const getAdaptiveMediaSrc = (
+  fileId: number | undefined,
+  fileName: string | undefined,
+  size: keyof typeof AdaptiveMediaSizes,
+): string => {
+  if (fileId === undefined || fileName === undefined) {
+    return '';
+  }
+
+  const mediaSize = AdaptiveMediaSizes[size];
+  return `/ohjaaja/cms/o/adaptive-media/image/${fileId}/${mediaSize}/${fileName}`;
 };


### PR DESCRIPTION

## Description
- Use Liferay's Adaptive Media url to fetch smaller version of the image for MediaCard

## Related JIRA ticket



https://jira.eduuni.fi/browse/OPHJOD-1239
