### PR TITLE
OPHJOD-1566: Add ArtikkelinKatselu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1215,7 +1215,7 @@
     },
     "node_modules/@jod/design-system": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/Opetushallitus/jod-design-system.git#6a381c65edcf6f56cd765c181639eba55d71bb6c",
+      "resolved": "git+ssh://git@github.com/Opetushallitus/jod-design-system.git#8ebc51ac5f6fc3fdac1d27f8fc6525bfa92d68d6",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ark-ui/react": "^5.3.1",

--- a/src/api/artikkelinKatselu.ts
+++ b/src/api/artikkelinKatselu.ts
@@ -1,0 +1,20 @@
+import { isLoggedIn } from '@/auth/auth';
+import { getAnonId } from '@/utils/anonId';
+import { client } from './client';
+
+const ARTIKKELIN_KATSELU_PATH = '/api/artikkeli/katselu';
+export const addArtikkelinKatselu = async (artikkeliId: number) => {
+  const anonyymiId = (await isLoggedIn()) ? undefined : getAnonId();
+  const { data, error } = await client.POST(ARTIKKELIN_KATSELU_PATH, {
+    body: {
+      artikkeliId,
+      anonyymiId,
+    },
+  });
+
+  if (!error) {
+    return data;
+  }
+
+  return null;
+};

--- a/src/api/schema.d.ts
+++ b/src/api/schema.d.ts
@@ -23,6 +23,23 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/artikkeli/katselu': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Adds a Katselu to the Artikkeli */
+    post: operations['artikkelinKatseluAdd'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/profiili/ohjaaja': {
     parameters: {
       query?: never;
@@ -31,6 +48,22 @@ export interface paths {
       cookie?: never;
     };
     get: operations['ohjaajaGet'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/profiili/ohjaaja/vienti': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations['ohjaajaExport'];
     put?: never;
     post?: never;
     delete?: never;
@@ -51,6 +84,15 @@ export interface components {
       /** Format: date-time */
       readonly luotu?: string;
     };
+    ArtikkelinKatseluDto: {
+      /** Format: uuid */
+      id?: string;
+      /** Format: int64 */
+      artikkeliId: number;
+      /** Format: date-time */
+      luotu?: string;
+      anonyymiId?: string;
+    };
     CsrfTokenDto: {
       token: string;
       headerName: string;
@@ -60,6 +102,10 @@ export interface components {
       etunimi?: string;
       sukunimi?: string;
       csrf: components['schemas']['CsrfTokenDto'];
+    };
+    OhjaajaExportDto: {
+      /** Format: uuid */
+      id?: string;
     };
   };
   responses: never;
@@ -134,6 +180,30 @@ export interface operations {
       };
     };
   };
+  artikkelinKatseluAdd: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ArtikkelinKatseluDto'];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': string;
+        };
+      };
+    };
+  };
   ohjaajaGet: {
     parameters: {
       query?: never;
@@ -150,6 +220,26 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['OhjaajaCsrfDto'];
+        };
+      };
+    };
+  };
+  ohjaajaExport: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['OhjaajaExportDto'];
         };
       };
     };

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -9,18 +9,23 @@ export const authStore: {
   ohjaajaPromise: undefined,
 };
 
-export const withOhjaajaContext = (
-  load: LoaderFunction<components['schemas']['OhjaajaCsrfDto'] | null>,
-  loginRequired = true,
-) => {
+type OhjaajaCsrfDto = components['schemas']['OhjaajaCsrfDto'];
+
+export const withOhjaajaContext = (load: LoaderFunction<OhjaajaCsrfDto | null>, loginRequired = true) => {
   return async (args: LoaderFunctionArgs) => {
     authStore.ohjaajaPromise ??= client.GET('/api/profiili/ohjaaja');
 
-    const { data = null } = (await authStore.ohjaajaPromise) as { data: components['schemas']['OhjaajaCsrfDto'] };
+    const { data = null } = (await authStore.ohjaajaPromise) as { data: OhjaajaCsrfDto };
     if (data) {
       registerCsrfMiddleware(data.csrf);
     }
 
     return !loginRequired || data ? await load({ ...args, context: data }) : redirect('/');
   };
+};
+
+export const isLoggedIn = async () => {
+  return (
+    authStore.ohjaajaPromise != undefined && ((await authStore.ohjaajaPromise) as { data: OhjaajaCsrfDto }).data != null
+  );
 };

--- a/src/routes/ContentDetails/loader.ts
+++ b/src/routes/ContentDetails/loader.ts
@@ -1,10 +1,11 @@
+import { addArtikkelinKatselu } from '@/api/artikkelinKatselu';
 import { components } from '@/api/schema';
 import { getContentByArticleId } from '@/services/cms-api';
 import { LoaderFunction } from 'react-router';
 
 const getContentDetailsLoader = (contentId: number) =>
   (async ({ context }) => {
-    const data = await getContentByArticleId(contentId);
+    const [data] = await Promise.all([getContentByArticleId(contentId), addArtikkelinKatselu(contentId)]);
     return { data, isLoggedIn: !!context };
   }) satisfies LoaderFunction<components['schemas']['OhjaajaCsrfDto'] | null>;
 

--- a/src/utils/anonId.test.ts
+++ b/src/utils/anonId.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getAnonId } from './anonId';
+
+const MOCK_UUID = '00000000-0000-4000-a000-000000000000';
+describe('getAnonId', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue(MOCK_UUID);
+  });
+
+  it('should return existing anonId if present in localStorage', () => {
+    localStorage.setItem('anonId', 'existing-id');
+    expect(getAnonId()).toBe('existing-id');
+  });
+
+  it('should generate and store new anonId if not present in localStorage', () => {
+    expect(getAnonId()).toBe(MOCK_UUID);
+    expect(localStorage.getItem('anonId')).toBe(MOCK_UUID);
+  });
+
+  it('should call crypto.randomUUID only when generating new id', () => {
+    const anonId1 = getAnonId();
+    const anonId2 = getAnonId();
+    expect(anonId1).toBe(anonId2);
+    expect(crypto.randomUUID).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/anonId.ts
+++ b/src/utils/anonId.ts
@@ -1,0 +1,11 @@
+export const getAnonId = () => {
+  const anonId = localStorage.getItem('anonId');
+
+  if (!anonId) {
+    const newAnonId = crypto.randomUUID();
+    localStorage.setItem('anonId', newAnonId);
+    return newAnonId;
+  }
+
+  return anonId;
+};


### PR DESCRIPTION
## Description
This PR implements the frontend functionality for logging article view events to the backend. The feature works for both authenticated and anonymous users:

* A persistent anonyymiId is generated and stored in localStorage.
* When an article is viewed, the app sends a POST request to /api/artikkeli/katselu including:
  * artikkeliId (always)
  * anonyymiId (only for anonymous users)

The backend handles storing the event with appropriate user identification.

## Related JIRA ticket
https://jira.eduuni.fi/browse/OPHJOD-1566
