### PR TITLE
OPHJOD-1690: Update DS, add logo to navigation menu and use updated footer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1217,7 +1217,7 @@
     },
     "node_modules/@jod/design-system": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/Opetushallitus/jod-design-system.git#0fb2bb7e002f7af400e930421ea7ba91e763ef39",
+      "resolved": "git+ssh://git@github.com/Opetushallitus/jod-design-system.git#07cfea67efd8fb76ffb06951ba0bd0b005ba6da0",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ark-ui/react": "^5.8.0",

--- a/src/components/NavMenu/NavMenu.tsx
+++ b/src/components/NavMenu/NavMenu.tsx
@@ -15,6 +15,20 @@ const FrontPageLink = ({ children, className }: LinkComponent) => {
   );
 };
 
+const LogoLink = ({
+  to,
+  className,
+  children,
+}: {
+  to: object | string;
+  className?: string;
+  children: React.ReactNode;
+}) => (
+  <Link to={to} className={className}>
+    {children}
+  </Link>
+);
+
 const LanguageSelectionLinkComponent = (generateLocalizedPath: (langCode: string) => string, langCode: string) => {
   const LanguageSelectionLink = (props: LinkComponent) => {
     const localizedPath = generateLocalizedPath(langCode);
@@ -73,6 +87,8 @@ export const NavMenu = ({ open, onClose }: { open: boolean; onClose: () => void 
       openSubMenuLabel={t('open-submenu')}
       frontPageLinkLabel={t('front-page')}
       onClose={onClose}
+      logo={{ to: `/${language}`, language, srText: t('osaamispolku') }}
+      logoLink={LogoLink}
       selectedLanguage={language}
       languageSelectionItems={languageSelectionItems}
       externalLinkSections={externalLinkSections}

--- a/src/i18n/fi/translation.json
+++ b/src/i18n/fi/translation.json
@@ -1,16 +1,18 @@
 {
+  "about-ai": "Tietoa tekoälyn käytöstä",
+  "about-us": "Tietoa palvelusta",
   "about-us-and-user-guide": "Tietoa palvelusta ja käyttöohjeet",
   "accessibility-statement": "Saavutettavuusseloste",
   "add-to-favorites": "Tallenna suosikiksi",
   "advisors-workspace": "Ohjaajan työpöytä",
   "back": "Takaisin",
+  "cancel": "Peruuta",
   "carousel": {
     "indicator": "Siirry sivulle {{index}}",
     "next": "Seuraava sivu",
     "prev": "Edellinen sivu"
   },
   "close-menu": "Sulje valikko",
-  "contents": "Sisällys",
   "content-details": {
     "additional-content": "Lisätietoja",
     "date-created": "Luotu:",
@@ -21,12 +23,32 @@
     "article-count_other": "{{count}} artikkelia",
     "show-more": "Näytä lisää"
   },
+  "contents": "Sisällys",
   "cookie-policy": "Evästekäytäntö",
   "copyright": "© JOD 2024. Kaikki oikeudet pidätetään.",
   "current-location": "Nykyinen sijainti",
-  "delete": "Poista",
-  "cancel": "Peruuta",
   "data-sources": "Datalähteet",
+  "delete": "Poista",
+  "error-boundary": {
+    "session-expired": "Istuntosi on vanhentunut. Sinun täytyy kirjautua palveluun uudelleen tai käyttää palvelua ilman kirjautumista.",
+    "title": "Tapahtui virhe",
+    "unexpected": "Tapahtui odottamaton virhe. Tämä voi johtua verkkoyhteyden katkeamisesta tai palvelun virheestä."
+  },
+  "footer": {
+    "cooperation-title": "Osaamipolku on toteutettu yhteistyössä seuraavien tahojen toimesta.",
+    "feedback-button-label": "Anna palautetta",
+    "feedback-content": "Haluamme kehittää Osaamispolkua vastaamaan paremmin juuri sinun tarpeita. Anna meille palautetta ja huomiomme sen kehitystyössä.",
+    "feedback-title": "Kerro meille mitä pidit palvelusta!",
+    "funding-title": "Palvelu on rahoitettu Euroopan RFF-rahoituksella.",
+    "logos": {
+      "keha-label": "KEHA-keskus",
+      "okm-label": "Opetus- ja kulttuuriministeriö",
+      "oph-label": "Opetushallitus",
+      "tem-label": "Työ- ja elinkeinoministeriö"
+    },
+    "more-info-description": "Mietityttääkö tietosuoja tai tekoälyn hyödyntäminen palvelussa? Alta löydät kootusti yleistä tietoa palvelusta ja sen käytöstä.",
+    "more-info-title": "Haluatko tietää lisää Osaamispolusta?"
+  },
   "front-page": "Etusivu",
   "front-page-navigation": "Ohjaajan osion etusivu",
   "home": {
@@ -45,23 +67,23 @@
   },
   "link-copied": "Linkki kopioitu!",
   "link-copy-failed": "Linkin kopiointi epäonnistui",
-  "login": "Kirjaudu sisään",
   "log-in-to-the-service": "Kirjaudu palveluun",
   "log-in-to-the-service-content": "Kirjautumalla palveluun voit keskustella sisällöistä, tallentaa niitä suosikeiksi ja kustomoida palvelussa sinulle näkyvää sisältöä omien kiinnostustesi mukaan. Palvelu käyttää suomi.fi.tunnistautumista. ",
+  "login": "Kirjaudu sisään",
   "logout": "Kirjaudu ulos",
   "menu": "Valikko",
   "navigation": {
     "external": {
+      "tietopalvelu": {
+        "description": "Tietoa päätöksentekijöille",
+        "label": "Tietopalvelu",
+        "url": "/tietopalvelu/fi"
+      },
       "title": "Osaamispolun sisältökokonaisuudet",
       "yksilo": {
+        "description": "Henkilökohtainen osaamispolkusi",
         "label": "Osaamispolkuni",
-        "url": "/yksilo/fi",
-        "description": "Henkilökohtainen osaamispolkusi"
-      },
-      "tietopalvelu": {
-        "label": "Tietopalvelu",
-        "url": "/tietopalvelu/fi",
-        "description": "Tietoa päätöksentekijöille"
+        "url": "/yksilo/fi"
       }
     }
   },
@@ -74,31 +96,32 @@
   "osaamispolku": "Osaamispolku",
   "pagination": {
     "next": "Siirry seuraavalle sivulle",
-    "previous": "Siirry edelliselle sivulle",
-    "page": "Sivu {{page}}"
+    "page": "Sivu {{page}}",
+    "previous": "Siirry edelliselle sivulle"
   },
   "print": "Tulosta",
   "privacy-policy": "Tietosuojaseloste",
+  "privacy-policy-and-cookies": "Tietosuojaseloste ja evästeet",
   "profile": {
     "details": {
       "greeting": "Hei {{firstName}} {{lastName}} - tervetuloa",
       "interest": {
-        "title": "Kiinnostukseni",
-        "description": "Valitsemalla sinua kiinnostavia asiasanoja, voimme tarjota palvelussa sinulle paremmin kohdistettuja sisältöjä. Näet myös kaiken muun palvelussa tarjottavan sisällön. Valintasi tallennetaan automaattisesti. "
+        "description": "Valitsemalla sinua kiinnostavia asiasanoja, voimme tarjota palvelussa sinulle paremmin kohdistettuja sisältöjä. Näet myös kaiken muun palvelussa tarjottavan sisällön. Valintasi tallennetaan automaattisesti. ",
+        "title": "Kiinnostukseni"
       },
       "introduction": {
-        "title": "Tietoa minusta",
         "description": "Voit täydentää omia tietojasi alla. Näytämme tietosi muille käyttäjille keskustelujen yhteydessä. Tietojen täydentäminen on vapaaehtoista.",
         "label": "Valitse työskentelypaikkasi",
-        "placeholder": "Valitse"
+        "placeholder": "Valitse",
+        "title": "Tietoa minusta"
       },
       "title": "Omat tiedot"
     },
     "favorites": {
       "description": "Suosikeiksi tallentamasi artikkelisisällöt löytyvät täältä. Voit tallentaa suosikkeja artikkelinostoista tai artikkelien sivuilta. Voit poistaa tallennetun suosikin tyhjentämällä valinnan.",
-      "favorite-count_zero": "Et ole vielä tallentanut suosikkeja.",
       "favorite-count_one": "Olet tallentanut yhden suosikin.",
       "favorite-count_other": "Olet tallentanut {{count}} suosikkia.",
+      "favorite-count_zero": "Et ole vielä tallentanut suosikkeja.",
       "filter": "Suodata",
       "no-favorites": "Voit tallentaa artikkeleita suosikeiksi klikkaamalla sydän-ikonia. Voit tutustua sisältöihin seuraavissa osioissa:",
       "no-tags": "Voit suodattaa tallentamiasi sisältöjä avainsanoihin perustuen.",
@@ -132,53 +155,53 @@
       "title": "Tervetuloa! Luo oma osaamispolkusi ja hyödynnä monipuoliset palvelut"
     },
     "preferences": {
-      "description": "Tällä sivulla voit valita, mihin tarkoituksiin toiminnastasi Ohjaajan osiossa kerättävää tietoa käytetään.",
       "delete-profile": {
-        "title": "Poista koko ohjaajan profiili ja kaikki siihen tallennetut tiedot",
-        "description": "Kaikki ohjaajan profiiliin tallennetut tiedot poistetaan pysyvästi, eikä niitä voi palauttaa. Huomioithan, että ohjaajan profiilin poisto ei vaikuta mahdollisesti luomaasi osaamisprofiiliin tai sen tietoihin. Jos haluat poistaa myös osaamisprofiilin, sinun tulee tehdä se Osaamispolun asetuksissa.",
         "action": "Poista ohjaajan profiili",
-        "confirm": "Haluatko varmasti poistaa ohjaajan profiilisi?"
+        "confirm": "Haluatko varmasti poistaa ohjaajan profiilisi?",
+        "description": "Kaikki ohjaajan profiiliin tallennetut tiedot poistetaan pysyvästi, eikä niitä voi palauttaa. Huomioithan, että ohjaajan profiilin poisto ei vaikuta mahdollisesti luomaasi osaamisprofiiliin tai sen tietoihin. Jos haluat poistaa myös osaamisprofiilin, sinun tulee tehdä se Osaamispolun asetuksissa.",
+        "title": "Poista koko ohjaajan profiili ja kaikki siihen tallennetut tiedot"
       },
+      "description": "Tällä sivulla voit valita, mihin tarkoituksiin toiminnastasi Ohjaajan osiossa kerättävää tietoa käytetään.",
       "disclosure-of-data": {
         "archiving": {
-          "title": "Arkistointi",
-          "description": "Selitys/tarkennus"
+          "description": "Selitys/tarkennus",
+          "title": "Arkistointi"
         },
         "competence-assessment": {
-          "title": "Osaamisen arviointi",
-          "description": "Selitys/tarkennus"
+          "description": "Selitys/tarkennus",
+          "title": "Osaamisen arviointi"
         },
         "description": "Voit valita, luovutetaanko tietosi rajapintojen kautta seuraaviin tarkoituksiin:",
         "development": {
-          "title": "Tutkimus",
-          "description": "Selitys/tarkennus"
+          "description": "Selitys/tarkennus",
+          "title": "Tutkimus"
         },
         "evaluation-of-education": {
-          "title": "Koulutuksen arviointi",
-          "description": "Selitys/tarkennus"
+          "description": "Selitys/tarkennus",
+          "title": "Koulutuksen arviointi"
         },
         "guidance-and-planning": {
-          "title": "Ohjaus ja suunnittelu",
-          "description": "Selitys/tarkennus"
+          "description": "Selitys/tarkennus",
+          "title": "Ohjaus ja suunnittelu"
         },
         "research": {
-          "title": "Tutkimus",
-          "description": "Selitys/tarkennus"
+          "description": "Selitys/tarkennus",
+          "title": "Tutkimus"
         },
         "statistics-and-monitoring": {
-          "title": "Tilastointi ja seuranta",
-          "description": "Selitys/tarkennus"
+          "description": "Selitys/tarkennus",
+          "title": "Tilastointi ja seuranta"
         },
         "teaching-evaluation": {
-          "title": "Opetuksen arviointi",
-          "description": "Selitys/tarkennus"
+          "description": "Selitys/tarkennus",
+          "title": "Opetuksen arviointi"
         },
         "title": "Tietojen luovutus anonymisoimattomana"
       },
       "download": {
-        "title": "Lataa talteen kaikki ohjaajan profiiliin tallennetut tietosi",
+        "action": "Lataa ohjaajan osion tiedot",
         "description": "Tämä tarkoittaa tietoja, jotka olet jakanut Ohjaajan osiossa sekä tietoja, joita olemme keränneet toiminnastasi. ",
-        "action": "Lataa ohjaajan osion tiedot"
+        "title": "Lataa talteen kaikki ohjaajan profiiliin tallennetut tietosi"
       },
       "title": "Asetukset"
     }
@@ -201,40 +224,35 @@
     "title": "Etsi palvelusta"
   },
   "search-results": {
-    "article-count_zero": "Ei tuloksia hakusanallasi",
     "article-count_one": "1 tulos hakusanallasi",
-    "article-count_other": "{{count}} tulosta hakusanallasi"
+    "article-count_other": "{{count}} tulosta hakusanallasi",
+    "article-count_zero": "Ei tuloksia hakusanallasi"
   },
   "select-language": "Valitse kieli",
   "share": "Jaa",
   "skiplinks": {
     "main": "Siirry pääsisältöön"
   },
-  "suggest-new-content-for-the-service": "Ehdota uutta sisältöä palveluun",
-  "suggest-new-content-for-the-service-content": "Oletko esimerkiksi käyttänyt ohjausmenetelmää, jota palvelusta ei löydy?\nEhdota meille palvelusta mielestäsi puuttuvaa sisältöä.",
   "slugs": {
     "accessibility-statement": "saavutettavuusseloste",
     "basic-information": "perustiedot",
     "cookie-policy": "evastekaytanto",
     "data-sources": "datalahteet",
     "privacy-policy": "tietosuojaseloste",
-    "search": "haku",
-    "terms-of-service": "kayttoehdot",
-    "user-guide": {
-      "index": "ohjeet",
-      "what-is-the-service": "mika-palvelu-on"
-    },
     "profile": {
       "details": "omat-tiedot",
       "favorites": "suosikit",
       "index": "ohjaajan-tyopoyta",
       "preferences": "asetukset"
+    },
+    "search": "haku",
+    "terms-of-service": "kayttoehdot",
+    "user-guide": {
+      "index": "ohjeet",
+      "what-is-the-service": "mika-palvelu-on"
     }
   },
-  "terms-of-service": "Käyttöehdot",
-  "error-boundary": {
-    "session-expired": "Istuntosi on vanhentunut. Sinun täytyy kirjautua palveluun uudelleen tai käyttää palvelua ilman kirjautumista.",
-    "title": "Tapahtui virhe",
-    "unexpected": "Tapahtui odottamaton virhe. Tämä voi johtua verkkoyhteyden katkeamisesta tai palvelun virheestä."
-  }
+  "suggest-new-content-for-the-service": "Ehdota uutta sisältöä palveluun",
+  "suggest-new-content-for-the-service-content": "Oletko esimerkiksi käyttänyt ohjausmenetelmää, jota palvelusta ei löydy?\nEhdota meille palvelusta mielestäsi puuttuvaa sisältöä.",
+  "terms-of-service": "Käyttöehdot"
 }

--- a/src/routes/Root/Root.tsx
+++ b/src/routes/Root/Root.tsx
@@ -3,40 +3,43 @@ import { NavMenu } from '@/components/NavMenu/NavMenu';
 import { Toaster } from '@/components/Toaster/Toaster';
 import { useMenuClickHandler } from '@/hooks/useMenuClickHandler';
 import i18n from '@/i18n/config';
-import { Footer, NavigationBar, SkipLink, useMediaQueries } from '@jod/design-system';
+import { Footer, NavigationBar, SkipLink } from '@jod/design-system';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdMenu } from 'react-icons/md';
 import { Link, NavLink, Outlet, ScrollRestoration, useLoaderData } from 'react-router';
 import { LogoutFormContext } from '.';
 
-const NavigationBarItem = (to: string, text: string) => ({
-  key: to,
-  component: ({ className }: { className: string }) => (
-    <NavLink to={to} className={className}>
-      {text}
-    </NavLink>
-  ),
-});
-
 const Root = () => {
   const {
     t,
     i18n: { language },
   } = useTranslation();
-  const { sm } = useMediaQueries();
   const [navMenuOpen, setNavMenuOpen] = React.useState(false);
   const [langMenuOpen, setLangMenuOpen] = React.useState(false);
 
-  const userGuide = t('slugs.user-guide.index');
-  const basicInformation = t('slugs.basic-information');
-  const footerItems: React.ComponentProps<typeof Footer>['items'] = [
-    NavigationBarItem(`${userGuide}/${t('slugs.user-guide.what-is-the-service')}`, t('about-us-and-user-guide')),
-    NavigationBarItem(`${basicInformation}/${t('slugs.cookie-policy')}`, t('cookie-policy')),
-    NavigationBarItem(`${basicInformation}/${t('slugs.data-sources')}`, t('data-sources')),
-    NavigationBarItem(`${basicInformation}/${t('slugs.terms-of-service')}`, t('terms-of-service')),
-    NavigationBarItem(`${basicInformation}/${t('slugs.accessibility-statement')}`, t('accessibility-statement')),
-    NavigationBarItem(`${basicInformation}/${t('slugs.privacy-policy')}`, t('privacy-policy')),
+  const infoSlug = t('slugs.basic-information');
+  const moreInfoLinks = [
+    {
+      to: `${t('slugs.user-guide.index')}/${t('slugs.user-guide.what-is-the-service')}`,
+      label: t('about-us'),
+    },
+    {
+      to: `${infoSlug}/${t('slugs.privacy-policy')}`,
+      label: t('privacy-policy-and-cookies'),
+    },
+    {
+      to: `${infoSlug}/${t('slugs.data-sources')}`,
+      label: t('data-sources'),
+    },
+    {
+      to: `${infoSlug}/${t('slugs.about-ai')}`,
+      label: t('about-ai'),
+    },
+    {
+      to: `${infoSlug}/${t('slugs.accessibility-statement')}`,
+      label: t('accessibility-statement'),
+    },
   ];
   const logoutForm = React.useRef<HTMLFormElement>(null);
 
@@ -107,11 +110,23 @@ const Root = () => {
         <Outlet />
       </LogoutFormContext.Provider>
       <Footer
-        items={footerItems}
         language={language}
+        okmLabel={t('footer.logos.okm-label')}
+        temLabel={t('footer.logos.tem-label')}
+        ophLabel={t('footer.logos.oph-label')}
+        kehaLabel={t('footer.logos.keha-label')}
+        cooperationTitle={t('footer.cooperation-title')}
+        fundingTitle={t('footer.funding-title')}
+        moreInfoTitle={t('footer.more-info-title')}
+        moreInfoDescription={t('footer.more-info-description')}
+        moreInfoLinks={moreInfoLinks}
+        MoreInfoLinkComponent={NavLink}
+        feedbackTitle={t('footer.feedback-title')}
+        feedbackContent={t('footer.feedback-content')}
+        feedbackButtonLabel={t('footer.feedback-button-label')}
+        feedbackBgImageClassName="bg-[url(@/../assets/home-1.avif)] bg-cover bg-[length:auto_auto] sm:bg-[length:auto_1000px] bg-[top_-0rem_right_-0rem] sm:bg-[top_-21rem_right_0rem]"
         copyright={t('copyright')}
-        variant="light"
-        className={!sm ? 'py-7' : undefined}
+        feedbackOnClick={() => console.log('feedbackOnClick')}
       />
       <Toaster />
       <ScrollRestoration />


### PR DESCRIPTION
## Description
* Update DS
* Put Osaamispolku logo to side navigation menu
* Use updated footer
* Add translations for the footer and sort the translation file

**Note**: The footer info links are copied from yksilö ui and are just placeholders, as the linked pages don't exist yet
**Note 2**: The footer uses a image called "home-1.avif". You might need to update the assets from S3.

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-1690

A bit funky screenshot 😅
![localhost_8180_ohjaaja_fi](https://github.com/user-attachments/assets/240d16bc-086e-441c-8c65-0a34ea84243c)
