### PR TITLE
OPHJOD-1713: Add DOMPurify hook to set target and rel attributes for links

### DIFF
--- a/src/utils/cms.ts
+++ b/src/utils/cms.ts
@@ -12,6 +12,14 @@ const AdaptiveMediaSizes = {
   preview: 'Preview-1000x0',
 };
 
+DOMPurify.addHook('afterSanitizeAttributes', function (node) {
+  // set all elements owning target to target=_blank
+  if ('target' in node) {
+    node.setAttribute('target', '_blank');
+    node.setAttribute('rel', 'noopener');
+  }
+});
+
 /**
  * Finds the content value from Liferay strucured content by label
  * @param item Structured content item


### PR DESCRIPTION
## Description
DOMPurify removes the target attribute by default, which prevents links from opening in a new tab. Content editors want links to open in a new tab without needing to set it manually.

This PR adds a DOMPurify hook that:
 - Sets target="_blank" and rel="noopener" for all elements with a target attribute to ensure that links open in a new tab safely.
 - Makes it easier for editors, as they no longer need to define link targets themselves.

## Related JIRA ticket
https://jira.eduuni.fi/browse/OPHJOD-1713
