### PR TITLE
OPHJOD-1790: Implement comments feature

### DIFF
--- a/src/api/artikkelinKommentit.ts
+++ b/src/api/artikkelinKommentit.ts
@@ -1,0 +1,48 @@
+import { client } from './client';
+
+export const getArtikkelinKommentit = async (artikkeliId: number, sivu: number) => {
+  const { data, error } = await client.GET(`/api/artikkeli/kommentit`, {
+    params: {
+      query: {
+        artikkeliId,
+        sivu,
+        koko: 4,
+      },
+    },
+  });
+  if (!error) {
+    return data;
+  }
+  return {
+    sisalto: [],
+    maara: 0,
+    sivuja: 0,
+  };
+};
+
+export const addArtikkelinKommentti = async (artikkeliId: number, kommentti: string) => {
+  const { data, error } = await client.POST(`/api/artikkeli/kommentit`, {
+    body: {
+      artikkeliId,
+      kommentti,
+    },
+  });
+  if (!error) {
+    return data;
+  }
+  throw new Error('Failed to add comment');
+};
+
+export const deleteArtikkelinKommentti = async (id: string) => {
+  const { error } = await client.DELETE('/api/artikkeli/kommentit/{id}', {
+    params: {
+      path: {
+        id,
+      },
+    },
+  });
+  if (!error) {
+    return true;
+  }
+  throw new Error('Failed to delete comment');
+};

--- a/src/api/schema.d.ts
+++ b/src/api/schema.d.ts
@@ -58,6 +58,24 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/artikkeli/kommentit': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Finds all artikkelin kommentit */
+    get: operations['artikkelinKommenttiFindAllArtikkelinKommentit'];
+    put?: never;
+    /** Creates a new artikkelin kommentti */
+    post: operations['artikkelinKommenttiCreateArtikkelinKommentti'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/artikkeli/katselu/{artikkeliId}': {
     parameters: {
       query?: never;
@@ -125,11 +143,30 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/artikkeli/kommentit/{id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Deletes an artikkelin kommentti by ID */
+    delete: operations['artikkelinKommenttiDeleteArtikkelinKommentti'];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
   schemas: {
     OhjaajaDto: {
+      /** Format: uuid */
+      id?: string;
       /** @enum {string} */
       tyoskentelyPaikka?:
         | 'PERUSASTE'
@@ -157,12 +194,25 @@ export interface components {
       /** Format: date-time */
       readonly luotu?: string;
     };
+    ArtikkelinKommenttiDto: {
+      /** Format: uuid */
+      readonly id?: string;
+      /** Format: int64 */
+      artikkeliId: number;
+      /** Format: uuid */
+      readonly ohjaajaId?: string;
+      kommentti: string;
+      /** Format: date-time */
+      readonly luotu?: string;
+    };
     CsrfTokenDto: {
       token: string;
       headerName: string;
       parameterName: string;
     };
     OhjaajaCsrfDto: {
+      /** Format: uuid */
+      id?: string;
       etunimi?: string;
       sukunimi?: string;
       csrf: components['schemas']['CsrfTokenDto'];
@@ -177,11 +227,31 @@ export interface components {
         | 'YKSITYINEN'
         | 'MUU';
     };
+    ArtikkelinKommenttiExportDto: {
+      /** Format: uuid */
+      id?: string;
+      /** Format: date-time */
+      luotu?: string;
+      /** Format: int64 */
+      artikkeliId?: number;
+      kommentti?: string;
+    };
     OhjaajaExportDto: {
       /** Format: uuid */
       id?: string;
+      /** @enum {string} */
+      tyoskentelyPaikka?:
+        | 'PERUSASTE'
+        | 'TOINEN_ASTE'
+        | 'KORKEAKOULU'
+        | 'AIKUISKOULUTUS'
+        | 'TYOLLISYYSPALVELUT'
+        | 'KOLMAS_SEKTORI'
+        | 'YKSITYINEN'
+        | 'MUU';
       suosikit?: components['schemas']['OhjaajanSuosikkiExportDto'][];
       kiinnostukset?: components['schemas']['OhjaajanKiinnostusExportDto'][];
+      kommentit?: components['schemas']['ArtikkelinKommenttiExportDto'][];
     };
     OhjaajanKiinnostusExportDto: {
       /** Format: uuid */
@@ -201,6 +271,19 @@ export interface components {
     };
     SivuDtoLong: {
       sisalto: number[];
+      /**
+       * Format: int64
+       * @example 30
+       */
+      maara: number;
+      /**
+       * Format: int32
+       * @example 3
+       */
+      sivuja: number;
+    };
+    SivuDtoArtikkelinKommenttiDto: {
+      sisalto: components['schemas']['ArtikkelinKommenttiDto'][];
       /**
        * Format: int64
        * @example 30
@@ -391,6 +474,52 @@ export interface operations {
       };
     };
   };
+  artikkelinKommenttiFindAllArtikkelinKommentit: {
+    parameters: {
+      query: {
+        artikkeliId: number;
+        sivu: number;
+        koko: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['SivuDtoArtikkelinKommenttiDto'];
+        };
+      };
+    };
+  };
+  artikkelinKommenttiCreateArtikkelinKommentti: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ArtikkelinKommenttiDto'];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
   artikkelinKatseluAdd: {
     parameters: {
       query?: never;
@@ -473,6 +602,26 @@ export interface operations {
         content: {
           'application/json': components['schemas']['SivuDtoLong'];
         };
+      };
+    };
+  };
+  artikkelinKommenttiDeleteArtikkelinKommentti: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
     };
   };

--- a/src/components/Comments/Comment.test.tsx
+++ b/src/components/Comments/Comment.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import Comment from './Comment';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('Comment', () => {
+  const mockProps = {
+    commentId: '123',
+    author: 'Test Author',
+    comment: 'Test comment content',
+    timestamp: '2023-01-01T12:00:00',
+    isOwnComment: false,
+    deleteComment: vi.fn(),
+  };
+
+  it('renders comment with correct content', () => {
+    render(<Comment {...mockProps} />);
+    expect(screen.getByText('Test comment content')).toBeInTheDocument();
+    expect(screen.getByText('01.01.2023 klo 12:00')).toBeInTheDocument();
+  });
+
+  it('shows delete button for own comments', () => {
+    render(<Comment {...mockProps} isOwnComment={true} />);
+    expect(screen.getByLabelText('comments.comment.delete.label')).toBeInTheDocument();
+  });
+
+  it('does not show delete button for others comments', () => {
+    render(<Comment {...mockProps} isOwnComment={false} />);
+    expect(screen.queryByLabelText('comments.comment.delete.label')).not.toBeInTheDocument();
+  });
+
+  it('calls deleteComment when delete is confirmed', async () => {
+    const user = userEvent.setup();
+    render(<Comment {...mockProps} isOwnComment={true} />);
+
+    await user.click(screen.getByLabelText('comments.comment.delete.label'));
+    await user.click(screen.getByText('comments.comment.delete.confirmText'));
+
+    expect(mockProps.deleteComment).toHaveBeenCalledWith('123');
+  });
+
+  it('preserves whitespace in comment text', () => {
+    const multilineComment = 'First line\nSecond line\nThird line';
+    render(<Comment {...mockProps} comment={multilineComment} />);
+    const commentElement = screen.getByText((_, element) => {
+      return element?.textContent === multilineComment;
+    });
+    expect(commentElement).toHaveClass('whitespace-pre-line');
+  });
+});

--- a/src/components/Comments/Comment.tsx
+++ b/src/components/Comments/Comment.tsx
@@ -1,0 +1,75 @@
+import { ConfirmDialog, IconButton } from '@jod/design-system';
+import { type RefAttributes } from 'react';
+import { useTranslation } from 'react-i18next';
+import PatternAvatar from '../PatternAvatar/PatternAvatar';
+
+interface CommentProps extends RefAttributes<HTMLDivElement> {
+  commentId: string;
+  author: string;
+  comment: string;
+  timestamp: string;
+  isOwnComment: boolean;
+  deleteComment: (id: string) => void;
+}
+
+const Comment = ({ commentId, author, comment, timestamp, isOwnComment, deleteComment, ref }: CommentProps) => {
+  const { t } = useTranslation();
+
+  const formattedTimestamp = new Date(timestamp)
+    .toLocaleString('fi-FI', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    })
+    .replace(',', ' klo')
+    .replace(/(\d{2})\.(\d{2})$/, '$1:$2');
+  return (
+    <div ref={ref} className="grid gap-2">
+      <div className="flex gap-3">
+        <div className="">
+          <PatternAvatar seed={author} size={32} />
+        </div>
+        <div className="rounded-lg bg-white flex-grow p-5 grid gap-2">
+          <div className="text-button-sm text-secondary-gray">{formattedTimestamp}</div>
+          <div className="text-body-sm text-primary-gray whitespace-pre-line">{comment}</div>
+        </div>
+      </div>
+      <div className="flex justify-end">
+        {isOwnComment ? (
+          <ConfirmDialog
+            title={t('comments.comment.delete.title')}
+            description={t('comments.comment.delete.description')}
+            onConfirm={() => deleteComment(commentId)}
+            cancelText={t('comments.comment.delete.cancelText')}
+            confirmText={t('comments.comment.delete.confirmText')}
+          >
+            {(showDeleteModal) => (
+              <IconButton
+                icon={<DeleteIcon />}
+                bgColor="gray"
+                onClick={showDeleteModal}
+                label={t('comments.comment.delete.label')}
+              />
+            )}
+          </ConfirmDialog>
+        ) : (
+          <div></div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const DeleteIcon = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M7 21C6.45 21 5.97917 20.8042 5.5875 20.4125C5.19583 20.0208 5 19.55 5 19V6H4V4H9V3H15V4H20V6H19V19C19 19.55 18.8042 20.0208 18.4125 20.4125C18.0208 20.8042 17.55 21 17 21H7ZM17 6H7V19H17V6ZM9 17H11V8H9V17ZM13 17H15V8H13V17Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
+export default Comment;

--- a/src/components/Comments/CommentInput.test.tsx
+++ b/src/components/Comments/CommentInput.test.tsx
@@ -1,0 +1,61 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CommentInput } from './CommentInput';
+
+// Mock translations
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('CommentInput', () => {
+  const mockProps = {
+    userId: 'test-user-id',
+    addComment: vi.fn(),
+    addingComment: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders textarea and send button when not adding comment', () => {
+    render(<CommentInput {...mockProps} />);
+    expect(screen.getByPlaceholderText('comments.comment.placeholder')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'comments.comment.send' })).toBeInTheDocument();
+  });
+
+  it('shows spinner when adding comment', () => {
+    render(<CommentInput {...mockProps} addingComment={true} />);
+    expect(screen.queryByPlaceholderText('comments.comment.placeholder')).not.toBeInTheDocument();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('disables send button when textarea is empty', () => {
+    render(<CommentInput {...mockProps} />);
+    const button = screen.getByRole('button', { name: 'comments.comment.send' });
+    expect(button).toBeDisabled();
+  });
+
+  it('enables send button when textarea has content', () => {
+    render(<CommentInput {...mockProps} />);
+    const textarea = screen.getByPlaceholderText('comments.comment.placeholder');
+    fireEvent.change(textarea, { target: { value: 'Test comment' } });
+    const button = screen.getByRole('button', { name: 'comments.comment.send' });
+    expect(button).toBeEnabled();
+  });
+
+  it('calls addComment with textarea value when send button clicked', async () => {
+    render(<CommentInput {...mockProps} />);
+    const textarea = screen.getByPlaceholderText('comments.comment.placeholder');
+    const button = screen.getByRole('button', { name: 'comments.comment.send' });
+
+    fireEvent.change(textarea, { target: { value: 'Test comment' } });
+    fireEvent.click(button);
+
+    expect(mockProps.addComment).toHaveBeenCalledWith('Test comment');
+    expect(textarea).toHaveValue('');
+  });
+});

--- a/src/components/Comments/CommentInput.tsx
+++ b/src/components/Comments/CommentInput.tsx
@@ -1,0 +1,68 @@
+import { Button, Spinner, Textarea } from '@jod/design-system';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import PatternAvatar from '../PatternAvatar/PatternAvatar';
+import { LIMITS } from './constants';
+
+interface CommentInputProps {
+  userId: string; // The ID of the user who is adding the comment
+  addComment: (comment: string) => void; // Function to handle adding a comment
+  addingComment: boolean; // State to indicate if a comment is being added
+}
+
+export const CommentInput = ({ userId, addComment, addingComment }: CommentInputProps) => {
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+  const [currentComment, setCurrentComment] = React.useState<string>('');
+
+  const { t } = useTranslation();
+
+  React.useEffect(() => {
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+      textareaRef.current.style.overflow = 'hidden';
+      textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
+    }
+  }, [currentComment]);
+
+  return (
+    <div className="flex gap-5 pt-5 border-t-border-gray border-t">
+      <div>
+        <PatternAvatar seed={userId} size={32} />
+      </div>
+      {addingComment ? (
+        <div className="flex-grow flex justify-center">
+          <Spinner size={16} color="accent" />
+        </div>
+      ) : (
+        <div className="flex flex-grow">
+          <Textarea
+            className="mr-3"
+            placeholder={t('comments.comment.placeholder')}
+            maxLength={LIMITS.COMMENT_MAX_LENGTH}
+            hideLabel
+            rows={1}
+            ref={textareaRef}
+            onChange={(e) => {
+              setCurrentComment(e.target.value);
+            }}
+            value={currentComment}
+          />
+
+          <Button
+            label={t('comments.comment.send')}
+            variant="accent"
+            disabled={currentComment.trim().length < 1}
+            className="self-end mb-2"
+            onClick={() => {
+              const comment = textareaRef.current?.value;
+              if (comment) {
+                addComment(comment);
+                setCurrentComment('');
+              }
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/Comments/Comments.test.tsx
+++ b/src/components/Comments/Comments.test.tsx
@@ -1,0 +1,98 @@
+import { addArtikkelinKommentti, deleteArtikkelinKommentti, getArtikkelinKommentit } from '@/api/artikkelinKommentit';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Mock } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Comments from './Comments';
+
+// Mock the API functions
+vi.mock('@/api/artikkelinKommentit', () => ({
+  getArtikkelinKommentit: vi.fn(),
+  addArtikkelinKommentti: vi.fn(),
+  deleteArtikkelinKommentti: vi.fn(),
+}));
+
+// Mock react-i18next
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('Comments', () => {
+  const mockComments = {
+    sisalto: [
+      {
+        id: '1',
+        ohjaajaId: 'user1',
+        kommentti: 'Test comment 1',
+        luotu: '2023-01-01T00:00:00Z',
+      },
+      {
+        id: '2',
+        ohjaajaId: 'user2',
+        kommentti: 'Test comment 2',
+        luotu: '2023-01-02T00:00:00Z',
+      },
+    ],
+    maara: 1,
+    sivuja: 1,
+  };
+
+  beforeEach(() => {
+    (getArtikkelinKommentit as Mock).mockResolvedValue(mockComments);
+  });
+
+  it('should render comments list', async () => {
+    render(<Comments articleId={1} userId="user1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Test comment 1')).toBeInTheDocument();
+      expect(screen.getByText('Test comment 2')).toBeInTheDocument();
+    });
+  });
+
+  it('should show no comments message when empty', async () => {
+    (getArtikkelinKommentit as Mock).mockResolvedValue({ sisalto: [], sivuja: 0 });
+
+    render(<Comments articleId={1} userId="user1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('comments.noComments')).toBeInTheDocument();
+    });
+  });
+
+  it('should add new comment', async () => {
+    HTMLDivElement.prototype.scrollTo = vi.fn();
+    render(<Comments articleId={1} userId="user1" />);
+
+    const input = screen.getByPlaceholderText('comments.comment.placeholder');
+    fireEvent.change(input, { target: { value: 'New comment' } });
+
+    const submitButton = screen.getByRole('button', { name: 'comments.comment.send' });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(addArtikkelinKommentti).toHaveBeenCalledWith(1, 'New comment');
+    });
+    expect(HTMLDivElement.prototype.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+  });
+
+  it('should delete comment', async () => {
+    render(<Comments articleId={1} userId="user1" />);
+    const user = userEvent.setup();
+    await waitFor(async () => {
+      await user.click(screen.getAllByLabelText('comments.comment.delete.label')[0]);
+      await user.click(screen.getByText('comments.comment.delete.confirmText'));
+    });
+
+    expect(deleteArtikkelinKommentti).toHaveBeenCalledWith('1');
+  });
+
+  it('should not show comment input when userId is not provided', async () => {
+    render(<Comments articleId={1} />);
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText('comments.comment.placeholder')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/Comments/Comments.tsx
+++ b/src/components/Comments/Comments.tsx
@@ -1,0 +1,128 @@
+import { addArtikkelinKommentti, deleteArtikkelinKommentti, getArtikkelinKommentit } from '@/api/artikkelinKommentit';
+import { components } from '@/api/schema';
+import { Spinner } from '@jod/design-system';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import Comment from './Comment';
+import { CommentInput } from './CommentInput';
+
+interface CommentsProps {
+  articleId: number;
+  userId?: string; // Optional userId for determining if the comment is the user's own
+}
+
+const Comments = ({ articleId, userId }: CommentsProps) => {
+  const { t } = useTranslation();
+
+  const commentsRef = React.useRef<HTMLDivElement>(null);
+
+  const [comments, setComments] = React.useState<components['schemas']['ArtikkelinKommenttiDto'][]>([]);
+  const [page, setPage] = React.useState<number>(1);
+  const [hasMore, setHasMore] = React.useState<boolean>(true);
+  const [loading, setLoading] = React.useState<boolean>(false);
+  const [addingComment, setAddingComment] = React.useState<boolean>(false);
+
+  const observer = React.useRef<IntersectionObserver | null>(null);
+
+  const lastPostElementRef = React.useCallback(
+    (node: HTMLDivElement) => {
+      if (loading) return;
+      if (observer.current) observer.current.disconnect();
+      observer.current = new IntersectionObserver(
+        (entries) => {
+          if (entries[0].isIntersecting && hasMore) {
+            setPage((prevPage) => prevPage + 1);
+          }
+        },
+        { threshold: 1.0 },
+      );
+      if (node) observer.current.observe(node);
+    },
+    [loading, hasMore],
+  );
+
+  const fetchComments = React.useCallback(
+    async (pageNum: number) => {
+      setLoading(true);
+      const commentsResponse = await getArtikkelinKommentit(articleId, pageNum - 1);
+      if (pageNum === 1) {
+        setComments(commentsResponse.sisalto);
+      } else {
+        setComments((prev) => [...prev, ...commentsResponse.sisalto]);
+      }
+      if (commentsResponse.sivuja <= pageNum) {
+        setHasMore(false);
+      } else {
+        setHasMore(true);
+      }
+      setLoading(false);
+      setAddingComment(false);
+    },
+    [articleId],
+  );
+
+  const addComment = async (comment: string) => {
+    setAddingComment(true);
+    try {
+      await addArtikkelinKommentti(articleId, comment);
+
+      if (page === 1) {
+        fetchComments(1); // Refresh comments if on the first page
+      } else {
+        setPage(1); // Reset to first page to fetch new comments
+      }
+      commentsRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
+    } catch (error) {
+      console.error('Error adding comment:', error);
+    }
+  };
+
+  const deleteComment = async (commentId: string) => {
+    try {
+      await deleteArtikkelinKommentti(commentId);
+      setComments((prev) => prev.filter((comment) => comment.id !== commentId));
+    } catch (error) {
+      console.error('Error deleting comment:', error);
+    }
+  };
+
+  React.useEffect(() => {
+    fetchComments(page);
+  }, [fetchComments, page]);
+
+  return (
+    <div className="py-7">
+      <h2 className="text-heading-2 pb-5">{t('comments.title')}</h2>
+      <p className="text-body-lg pb-7">{t('comments.description')}</p>
+      <div className="grid gap-4 pb-5 max-h-[450px] overflow-y-auto" ref={commentsRef}>
+        {comments.length === 0 && !loading && (
+          <div className="text-body-md text-primary-gray pt-3 pb-6">{t('comments.noComments')}</div>
+        )}
+        {comments.map((comment, index) => {
+          if (comment.id && comment.luotu) {
+            return (
+              <Comment
+                key={comment.id}
+                commentId={comment.id}
+                author={comment.ohjaajaId ?? 'Anonymous'}
+                comment={comment.kommentti}
+                timestamp={comment.luotu}
+                isOwnComment={comment.ohjaajaId === userId}
+                deleteComment={deleteComment}
+                ref={index === comments.length - 1 ? lastPostElementRef : null}
+              />
+            );
+          }
+        })}
+        {loading && (
+          <div className="flex justify-center py-4">
+            <Spinner size={16} color="accent" />
+          </div>
+        )}
+      </div>
+      {userId && <CommentInput userId={userId} addComment={addComment} addingComment={addingComment} />}
+    </div>
+  );
+};
+
+export default Comments;

--- a/src/components/Comments/constants.ts
+++ b/src/components/Comments/constants.ts
@@ -1,0 +1,3 @@
+export const LIMITS = {
+  COMMENT_MAX_LENGTH: 2000,
+};

--- a/src/components/PatternAvatar/PatternAvatar.tsx
+++ b/src/components/PatternAvatar/PatternAvatar.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+interface PatternAvatarProps {
+  seed: string;
+  size?: number; // in pixels
+  rows?: number;
+  cols?: number;
+}
+
+const PatternAvatar: React.FC<PatternAvatarProps> = ({ seed, size = 100, rows = 20, cols = 20 }) => {
+  const cellSize = size / rows;
+
+  // Create a simple hash from the seed
+  const hash = Array.from(new TextEncoder().encode(seed)).reduce((a, b) => a + b, 0);
+
+  // Use the hash to generate color hue
+  const hue = hash % 360;
+  const fillColor = `hsl(${hue}, 70%, 60%)`;
+
+  // Generate grid pattern (only left half, then mirror)
+  const pattern: boolean[][] = [];
+  const halfCols = Math.ceil(cols / 2);
+  let counter = 0;
+
+  for (let y = 0; y < rows; y++) {
+    const row: boolean[] = [];
+    for (let x = 0; x < halfCols; x++) {
+      const bit = seed.charCodeAt(counter++ % seed.length) % 2 === 0;
+      row.push(bit);
+    }
+    pattern.push(row);
+  }
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      xmlns="http://www.w3.org/2000/svg"
+      style={{ borderRadius: '50%', background: '#fff' }}
+    >
+      <clipPath id="circleClip">
+        <circle cx={size / 2} cy={size / 2} r={size / 2} />
+      </clipPath>
+      <g clipPath="url(#circleClip)">
+        {pattern.map((row, y) =>
+          row.map((on, x) => {
+            if (!on) return null;
+            const px = x * cellSize;
+            const py = y * cellSize;
+            const mirrorPx = (cols - 1 - x) * cellSize;
+            return (
+              <React.Fragment key={`${seed}-${x * rows + y}`}>
+                <rect x={px} y={py} width={cellSize} height={cellSize} fill={fillColor} />
+                {x !== cols - 1 - x && <rect x={mirrorPx} y={py} width={cellSize} height={cellSize} fill={fillColor} />}
+              </React.Fragment>
+            );
+          }),
+        )}
+      </g>
+    </svg>
+  );
+};
+
+export default PatternAvatar;

--- a/src/i18n/fi/translation.json
+++ b/src/i18n/fi/translation.json
@@ -13,6 +13,22 @@
     "prev": "Edellinen sivu"
   },
   "close-menu": "Sulje valikko",
+  "comments": {
+    "comment": {
+      "delete": {
+        "title": "Haluatko varmasti poistaa kommentin?",
+        "description": "Toimintoa ei voi peruuttaa",
+        "cancelText": "Peruuta",
+        "confirmText": "Poista kommentti",
+        "label": "Poista kommentti"
+      },
+      "placeholder": "Kirjoita kommentti",
+      "send": "Lähetä"
+    },
+    "description": "Voit kommentoida artikkelin sisältöä sisäänkirjautuneena. Kommentit näkyvät kaikille käyttäjille. Älä jaa kommenteissa henkilö- tai muuta yksityistä tietoa.",
+    "title": "Kommentoi sisältöä",
+    "noComments": "Ei vielä kommentteja."
+  },
   "competency-path-portal": "Osaamispolkuportaali",
   "content-details": {
     "additional-content": "Lisätietoja",

--- a/src/routes/ContentDetails/ContentDetails.tsx
+++ b/src/routes/ContentDetails/ContentDetails.tsx
@@ -1,4 +1,5 @@
 import { MainLayout } from '@/components';
+import Comments from '@/components/Comments/Comments';
 import { useSuosikitStore } from '@/stores/useSuosikitStore';
 import { ContentDocument, ContentLink } from '@/types/cms-content';
 import { copyToClipboard } from '@/utils/clipboard';
@@ -48,7 +49,7 @@ interface DocumentsAndLinksProps {
 }
 
 const ContentDetails = () => {
-  const { data, isLoggedIn } = useLoaderData<LoaderData>();
+  const { data, isLoggedIn, userId } = useLoaderData<LoaderData>();
   const {
     i18n: { language },
     t,
@@ -162,6 +163,8 @@ const ContentDetails = () => {
           </ul>
         )}
       </div>
+
+      {data.id && <Comments articleId={data.id} userId={userId} />}
     </MainLayout>
   );
 };

--- a/src/routes/ContentDetails/loader.ts
+++ b/src/routes/ContentDetails/loader.ts
@@ -6,7 +6,7 @@ import { LoaderFunction } from 'react-router';
 const getContentDetailsLoader = (contentId: number) =>
   (async ({ context }) => {
     const [data] = await Promise.all([getContentByArticleId(contentId), addArtikkelinKatselu(contentId)]);
-    return { data, isLoggedIn: !!context };
+    return { data, isLoggedIn: !!context, userId: context?.id };
   }) satisfies LoaderFunction<components['schemas']['OhjaajaCsrfDto'] | null>;
 
 export type LoaderData = Awaited<ReturnType<ReturnType<typeof getContentDetailsLoader>>>;

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -15,3 +15,11 @@ Object.defineProperty(window, 'matchMedia', {
     dispatchEvent: vi.fn(),
   })),
 });
+
+class IntersectionObserverMock {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+
+vi.stubGlobal('IntersectionObserver', IntersectionObserverMock);


### PR DESCRIPTION
## Description
Implement comments feature
* Authenticated users only can post comments.
* Comments are plain text (no rich formatting).
* Comments are displayed under the article.
* User identity is anonymous: only the avatar is shown, not the username or any other identifying information.
* Users can delete their own comments.

Not included:
* Reporting inappropriate content is not yet implemented. This will be handled in a separate ticket.

Figma layouts:
<img width="485" height="451" alt="image" src="https://github.com/user-attachments/assets/11aaf64f-dd20-4057-8aaf-6890a7b60708" />
<img width="1730" height="1662" alt="image" src="https://github.com/user-attachments/assets/66512253-7e38-45aa-94a0-fecbd5a63a56" />


## Related JIRA ticket
https://jira.eduuni.fi/browse/OPHJOD-1790
