### PR TITLE
OPHJOD-1975: Use Select component instead of Combobox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1216,7 +1216,7 @@
     },
     "node_modules/@jod/design-system": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/Opetushallitus/jod-design-system.git#f9dd3bda0fe6a3812070ab75e64daeb159fde7f2",
+      "resolved": "git+ssh://git@github.com/Opetushallitus/jod-design-system.git#b1125be872c32d89b83f62c68cd66fb7c4c2a8ca",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ark-ui/react": "^5.18.3",

--- a/src/routes/Profile/Details/Details.tsx
+++ b/src/routes/Profile/Details/Details.tsx
@@ -4,7 +4,7 @@ import { MainLayout } from '@/components';
 import { ProfileNavigation } from '@/components/MainLayout/ProfileNavigation';
 import { useTags } from '@/hooks/useTags';
 import { useKiinnostuksetStore } from '@/stores/useKiinnostuksetStore';
-import { Checkbox, Combobox } from '@jod/design-system';
+import { Checkbox, Select } from '@jod/design-system';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLoaderData } from 'react-router';
@@ -71,7 +71,7 @@ const Details = () => {
           <p className="text-body-md mb-6" data-testid="profile-details-intro-description">
             {t('profile.details.introduction.description')}
           </p>
-          <Combobox
+          <Select
             label={t('profile.details.workplace.label')}
             placeholder={t('profile.details.workplace.placeholder')}
             selected={currentTyoskentelyPaikka ?? ''}


### PR DESCRIPTION

## Description
Replaced the previously used Combobox component with the new Select component.

 * The Select component no longer blocks vertical scrolling when the menu is open, fixing the issue where zoomed-in screens caused options to go off-screen without a way to scroll to them.

 * The new component does not include the search functionality, which was considered unnecessary since all options fit into view. This also resolves the confusing behavior where the search string persisted after selecting an option.


## Related JIRA ticket
https://jira.eduuni.fi/browse/OPHJOD-1975
