### PR TITLE
OPHJOD-1987: Increase default visible item count in CategoryListing component

### DIFF
--- a/src/routes/Category/CategoryListing.tsx
+++ b/src/routes/Category/CategoryListing.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { useLoaderData } from 'react-router';
 import { LoaderData } from './loader';
 
-const VISIBLE_ITEM_COUNT = 6;
+const VISIBLE_ITEM_COUNT = 10;
 
 const CategoryListing = () => {
   const { newestCategoryContent, isLoggedIn } = useLoaderData<LoaderData>();


### PR DESCRIPTION
## Description
Increase default visible item count from 6 to 10 in CategoryListing component

## Related JIRA ticket

https://jira.eduuni.fi/browse/OPHJOD-1987
