### PR TITLE
OPHJOD-2296: Fix LanguageButton & UserButton overlapping NoteStack

### DIFF
--- a/src/components/LanguageButton/LanguageButton.tsx
+++ b/src/components/LanguageButton/LanguageButton.tsx
@@ -36,7 +36,12 @@ export const LanguageButton = ({ onClick, langMenuOpen, menuRef, onMenuBlur, onM
         {caret}
       </button>
       {langMenuOpen && (
-        <div ref={menuRef} onBlur={onMenuBlur} className="absolute right-0 translate-y-8" data-testid="language-menu">
+        <div
+          ref={menuRef}
+          onBlur={onMenuBlur}
+          className="z-60 absolute right-0 translate-y-8"
+          data-testid="language-menu"
+        >
           <LanguageMenu onClick={onMenuClick} />
         </div>
       )}

--- a/src/components/UserButton/UserButton.tsx
+++ b/src/components/UserButton/UserButton.tsx
@@ -45,7 +45,11 @@ export const UserButton = ({ onLogout, onClick }: UserButtonProps) => {
         {caret}
       </button>
       {userMenuOpen && (
-        <div ref={userMenuRef} className="absolute right-0 min-w-max translate-y-8 transform" data-testid="user-menu">
+        <div
+          ref={userMenuRef}
+          className="z-60 absolute right-0 min-w-max translate-y-8 transform"
+          data-testid="user-menu"
+        >
           <PopupList classNames="gap-2">
             <NavLink
               to={userMenuProfileFrontUrl}


### PR DESCRIPTION
<!-- Have you ran tests and they pass?
Did builds complete successfully?
Remembered to run linters?
-->

## Description

<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

Fix LanguageButton & UserButton's menus overlapping with the NoteStack

## Screenshot

<img width="600"  alt="image" src="https://github.com/user-attachments/assets/e26eef69-867e-48de-94ca-3ad7364f710e" />


## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2296
