### PR TITLE
OPHJOD-2484: Fix own comment identification logic in Comments component

### DIFF
--- a/src/components/Comments/Comments.tsx
+++ b/src/components/Comments/Comments.tsx
@@ -127,7 +127,7 @@ const Comments = ({ articleErc, userId }: CommentsProps) => {
                 author={comment.ohjaajaId ?? 'Anonymous'}
                 comment={comment.kommentti}
                 timestamp={comment.luotu}
-                isOwnComment={comment.ohjaajaId === userId}
+                isOwnComment={userId !== undefined && comment.ohjaajaId === userId}
                 deleteComment={deleteComment}
                 reportComment={reportComment}
                 ref={index === comments.length - 1 ? lastPostElementRef : null}


### PR DESCRIPTION


## Description
Fix own comment identification logic in Comments component

## Related JIRA ticket
https://jira.eduuni.fi/browse/OPHJOD-2484
