### PR TITLE
OPHJOD-3337: Update DS to use new cookie consent version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hookform/error-message": "2.0.1",
         "@hookform/resolvers": "5.2.2",
-        "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260410-1/jod-design-system-0.0.0.tgz",
+        "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260417-3/jod-design-system-0.0.0.tgz",
         "dompurify": "3.3.1",
         "i18next": "25.8.10",
         "i18next-http-backend": "3.0.2",
@@ -1062,8 +1062,8 @@
     },
     "node_modules/@jod/design-system": {
       "version": "0.0.0",
-      "resolved": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260410-1/jod-design-system-0.0.0.tgz",
-      "integrity": "sha512-9VMo7nM25B5vGzgElp+ADnXMDjOdjr0vCROBpPtbn8WgvHiq9saus4spZr0YcQLmThgzZ5su6gLZnqW7/bP5cg==",
+      "resolved": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260417-3/jod-design-system-0.0.0.tgz",
+      "integrity": "sha512-ODUYxg60E2qPU/EOJzymlCdmwDe6fcaFhKBZJ9qLKZEANEkbXlApPvyipudbpZgSf5p13SkARHMfwt21oLxKlw==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ark-ui/react": "5.30.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@hookform/error-message": "2.0.1",
     "@hookform/resolvers": "5.2.2",
-    "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260410-1/jod-design-system-0.0.0.tgz",
+    "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260417-3/jod-design-system-0.0.0.tgz",
     "dompurify": "3.3.1",
     "i18next": "25.8.10",
     "i18next-http-backend": "3.0.2",

--- a/src/routes/Root/Root.tsx
+++ b/src/routes/Root/Root.tsx
@@ -31,6 +31,28 @@ import { useTranslation } from 'react-i18next';
 import { Link, NavLink, Outlet, ScrollRestoration, useFetcher, useLocation, useMatch } from 'react-router';
 import { LogoutFormContext } from '.';
 
+const LanguageButtonWrapper = () => {
+  const {
+    i18n: { language },
+  } = useTranslation();
+  const { generateLocalizedPath } = useLocalizedRoutes();
+  return (
+    <LanguageButton
+      serviceVariant="ohjaaja"
+      testId="language-button"
+      language={language as LangCode}
+      supportedLanguageCodes={supportedLanguageCodes}
+      generateLocalizedPath={generateLocalizedPath}
+      linkComponent={Link}
+      translations={{
+        fi: { change: 'Vaihda kieli.', label: langLabels.fi },
+        sv: { change: 'Andra språk.', label: langLabels.sv },
+        en: { change: 'Change language.', label: langLabels.en },
+      }}
+    />
+  );
+};
+
 const Root = () => {
   const {
     t,
@@ -42,7 +64,6 @@ const Root = () => {
   const [searchInputVisible, setSearchInputVisible] = React.useState(false);
   const { sm } = useMediaQueries();
   const location = useLocation();
-  const { generateLocalizedPath } = useLocalizedRoutes();
   const { addPermanentNote, addTemporaryNote, removeTemporaryNote, removePermanentNote } = useNoteStack();
 
   const sessionWarningNoteId = 'session-expiration-warning';
@@ -228,21 +249,7 @@ const Root = () => {
         <NavigationBar
           logo={{ to: `/${language}`, language, srText: t('common:osaamispolku') }}
           menuComponent={<MenuButton label={t('common:menu')} onClick={() => setNavMenuOpen(!navMenuOpen)} />}
-          languageButtonComponent={
-            <LanguageButton
-              serviceVariant="ohjaaja"
-              testId="language-button"
-              language={language as LangCode}
-              supportedLanguageCodes={supportedLanguageCodes}
-              generateLocalizedPath={generateLocalizedPath}
-              linkComponent={Link}
-              translations={{
-                fi: { change: 'Vaihda kieli.', label: langLabels.fi },
-                sv: { change: 'Andra språk.', label: langLabels.sv },
-                en: { change: 'Change language.', label: langLabels.en },
-              }}
-            />
-          }
+          languageButtonComponent={<LanguageButtonWrapper />}
           userButtonComponent={
             <UserButton
               serviceVariant="ohjaaja"
@@ -323,6 +330,7 @@ const RootWithCookieConsentProvider = () => {
   return (
     <CookieConsentProvider
       serviceVariant="ohjaaja"
+      languageButtonComponent={<LanguageButtonWrapper />}
       translations={{
         guard: {
           buttonLabel: t('common:cookie-consent.guard.buttonLabel'),
@@ -337,10 +345,10 @@ const RootWithCookieConsentProvider = () => {
           currentSelectionLabel: t('common:cookie-consent.modal.currentSelectionLabel'),
           declineOptionalLabel: t('common:cookie-consent.modal.declineOptionalLabel'),
           description: t('common:cookie-consent.modal.description'),
-          hereLabel: t('common:cookie-consent.modal.hereLabel'),
           name: t('common:cookie-consent.modal.name'),
           readMoreHref: t('common:cookie-consent.modal.readMoreHref'),
           readMoreLabel: t('common:cookie-consent.modal.readMoreLabel'),
+          externalLinkIconAriaLabel: t('common:external-link'),
           statisticsDescription: t('common:cookie-consent.modal.statisticsDescription'),
           title: t('common:cookie-consent.modal.title'),
         },


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
- Update DS to use new cookie consent version
<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-3337
