### PR TITLE
OPHJOD-2133: Update color token usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hookform/error-message": "2.0.1",
         "@hookform/resolvers": "5.4.0",
-        "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260608-2/jod-design-system-0.0.0.tgz",
+        "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260612-1/jod-design-system-0.0.0.tgz",
         "dompurify": "3.4.5",
         "i18next": "26.2.0",
         "i18next-http-backend": "4.0.0",
@@ -889,8 +889,8 @@
     },
     "node_modules/@jod/design-system": {
       "version": "0.0.0",
-      "resolved": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260608-2/jod-design-system-0.0.0.tgz",
-      "integrity": "sha512-cetrI/nJusi4GI5mo7OGmywa3wXBOLFltPIA4vFUqSrdhmqBJAXywAowcHHP4XdKnytE0ozLTKKcaD5MTblKDA==",
+      "resolved": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260612-1/jod-design-system-0.0.0.tgz",
+      "integrity": "sha512-QR5I89D2wvaR9bq5p/HS+1iiOILF6S+Az/7oG77TokT5TVhZSgtVpeDI20QrOoAHca4d1JqepXcfgKuYsixozg==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ark-ui/react": "5.36.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@hookform/error-message": "2.0.1",
     "@hookform/resolvers": "5.4.0",
-    "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260608-2/jod-design-system-0.0.0.tgz",
+    "@jod/design-system": "https://github.com/Opetushallitus/jod-design-system/releases/download/rel-20260612-1/jod-design-system-0.0.0.tgz",
     "dompurify": "3.4.5",
     "i18next": "26.2.0",
     "i18next-http-backend": "4.0.0",

--- a/src/components/ButtonMenu/SortMenu.tsx
+++ b/src/components/ButtonMenu/SortMenu.tsx
@@ -29,7 +29,7 @@ export const SortMenu = ({
 }: SortMenuProps) => {
   return (
     <ButtonMenu
-      triggerIcon={<JodSort size={18} className="text-secondary-2-dark" />}
+      triggerIcon={<JodSort size={18} className="text-primary-2-dark" />}
       triggerLabel={label}
       className={className}
       menuClassName={menuClassName}

--- a/src/components/Comments/Comment.tsx
+++ b/src/components/Comments/Comment.tsx
@@ -33,12 +33,12 @@ const Button = ({
     aria-label={label}
     type="button"
     onClick={onClick}
-    className={`group flex min-h-7 cursor-pointer items-center gap-2 rounded-[30px] bg-bg-gray-2 px-5 text-button-sm outline-offset-2 select-none focus-visible:outline-secondary-1-dark disabled:cursor-not-allowed ${danger ? 'hover:text-underline text-alert-text-2' : 'text-secondary-gray hover:text-secondary-1-dark focus-visible:text-secondary-1-dark active:text-secondary-1-dark-2'} `}
+    className={`group focus-visible:outline-secondary-1-dark flex min-h-7 cursor-pointer items-center gap-2 rounded-[30px] bg-bg-gray-2 px-5 text-button-sm outline-offset-2 select-none disabled:cursor-not-allowed ${danger ? 'hover:text-underline text-alert-2' : 'hover:text-secondary-1-dark focus-visible:text-secondary-1-dark active:text-secondary-1-dark-2 text-secondary-gray'} `}
     data-testid={dataTestid}
   >
     <div
       aria-hidden="true"
-      className={`${danger ? 'text-[#E35750]' : 'text-secondary-gray group-hover:text-secondary-1-dark group-focus-visible:text-secondary-1-dark group-active:text-secondary-1-dark-2'}`}
+      className={`${danger ? 'text-[#E35750]' : 'group-hover:text-secondary-1-dark group-focus-visible:text-secondary-1-dark group-active:text-secondary-1-dark-2 text-secondary-gray'}`}
     >
       {icon}
     </div>

--- a/src/components/EmptyStateWithCategoryLinks/EmptyStateWithCategoryLinks.tsx
+++ b/src/components/EmptyStateWithCategoryLinks/EmptyStateWithCategoryLinks.tsx
@@ -31,7 +31,7 @@ export const EmptyStateWithCategoryLinks = ({
         <p className="font-bold mb-3 font-arial text-body-md">{t('category-links.title')}</p>
         <Link
           to={`/${language}/${getMainCategoryPath(language, 0)}`}
-          className="flex items-center gap-2 p-2 text-button-sm text-secondary-2-dark"
+          className="flex items-center gap-2 p-2 text-button-sm text-primary-2-dark"
           data-testid={`${testIdPrefix}-link-category-0`}
         >
           {getMainCategory(language, 0)?.title ?? ''} <JodArrowRight size={20} />
@@ -39,7 +39,7 @@ export const EmptyStateWithCategoryLinks = ({
 
         <Link
           to={`/${language}/${getMainCategoryPath(language, 1)}`}
-          className="flex items-center gap-2 p-2 text-button-sm text-secondary-2-dark"
+          className="flex items-center gap-2 p-2 text-button-sm text-primary-2-dark"
           data-testid={`${testIdPrefix}-link-category-1`}
         >
           {getMainCategory(language, 1)?.title ?? ''} <JodArrowRight size={20} />
@@ -47,7 +47,7 @@ export const EmptyStateWithCategoryLinks = ({
 
         <Link
           to={`/${language}/${getMainCategoryPath(language, 2)}`}
-          className="flex items-center gap-2 p-2 text-button-sm text-secondary-2-dark"
+          className="flex items-center gap-2 p-2 text-button-sm text-primary-2-dark"
           data-testid={`${testIdPrefix}-link-category-2`}
         >
           {getMainCategory(language, 2)?.title ?? ''} <JodArrowRight size={20} />

--- a/src/components/GuidanceCard/GuidanceCard.tsx
+++ b/src/components/GuidanceCard/GuidanceCard.tsx
@@ -18,7 +18,7 @@ const GuidanceCard = () => {
       title={t('guidance-card.title')}
       content={t('guidance-card.description')}
       buttonText={t('guidance-card.link-text')}
-      backgroundColor="var(--ds-color-secondary-2-dark)"
+      backgroundColor="var(--ds-color-primary-2-dark)"
       icon={<JodOpenInNew ariaLabel={t('common:external-link')} />}
     />
   );

--- a/src/components/LoginBanner/LoginBanner.tsx
+++ b/src/components/LoginBanner/LoginBanner.tsx
@@ -17,7 +17,7 @@ export const LoginBanner = () => {
         level="h2"
         title={t('log-in-to-the-service-title')}
         content={t('log-in-to-the-service-content')}
-        backgroundColor="var(--ds-color-secondary-2-dark)"
+        backgroundColor="var(--ds-color-primary-2-dark)"
         data-testid="login-banner-card"
       />
     </div>

--- a/src/components/SuggestNewContent/SuggestNewContent.tsx
+++ b/src/components/SuggestNewContent/SuggestNewContent.tsx
@@ -25,7 +25,7 @@ export const SuggestNewContent = () => {
       level="h2"
       title={t('suggest-new-content-for-the-service')}
       content={t('suggest-new-content-for-the-service-content')}
-      backgroundColor="var(--ds-color-secondary-2-dark-2)"
+      backgroundColor="var(--ds-color-primary-2-dark-2)"
       data-testid="suggest-new-content-card"
       hideIcon
     />
@@ -35,7 +35,7 @@ export const SuggestNewContent = () => {
       level="h2"
       title={t('suggest-new-content-for-the-service')}
       content={t('suggest-new-content-for-the-service-content')}
-      backgroundColor="var(--ds-color-secondary-2-dark-2)"
+      backgroundColor="var(--ds-color-primary-2-dark-2)"
       data-testid="suggest-new-content-card-anonymous"
       linkComponent={getLinkTo(`/${i18n.language}/${t('slugs.profile.login')}`)}
     />

--- a/src/routes/ContentDetails/ContentDetails.tsx
+++ b/src/routes/ContentDetails/ContentDetails.tsx
@@ -150,7 +150,7 @@ const ContentDetails = () => {
               level="h2"
               title={t('access-content-later-title')}
               content={t('access-content-later-content')}
-              backgroundColor="var(--ds-color-secondary-2-dark)"
+              backgroundColor="var(--ds-color-primary-2-dark)"
               data-testid="access-content-later-card"
               linkComponent={getLinkTo(`/${language}/${t('slugs.profile.login')}`)}
             />

--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -78,7 +78,7 @@ const Home = () => {
           hero
           title={t('home.card-1-title')}
           content={t('home.card-1-content')}
-          backgroundColor="var(--ds-color-secondary-2-dark-2)"
+          backgroundColor="var(--ds-color-primary-2-dark-2)"
           className="lg:w-1/2"
         />
       </div>
@@ -88,7 +88,7 @@ const Home = () => {
           level="h2"
           title={t('home.card-2-title')}
           content={t('home.card-2-content')}
-          backgroundColor="var(--ds-color-secondary-2-dark)"
+          backgroundColor="var(--ds-color-primary-2-dark)"
           className="flex-1"
           buttonText={t('home.card-2-button-text')}
         />
@@ -97,7 +97,7 @@ const Home = () => {
           level="h2"
           title={t('home.card-3-title')}
           content={t('home.card-3-content')}
-          backgroundColor="var(--ds-color-secondary-2-dark-2)"
+          backgroundColor="var(--ds-color-primary-2-dark-2)"
           className="flex-1"
           buttonText={t('home.card-3-button-text')}
         />
@@ -106,7 +106,7 @@ const Home = () => {
           level="h2"
           title={t('home.card-4-title')}
           content={t('home.card-4-content')}
-          backgroundColor="var(--ds-color-secondary-2-dark)"
+          backgroundColor="var(--ds-color-primary-2-dark)"
           className="flex-1"
           buttonText={t('home.card-4-button-text')}
         />
@@ -124,7 +124,7 @@ const Home = () => {
               title={t('home.favorites')}
               content={t('home.favorites-content')}
               buttonText={t('home.favorites-button-label')}
-              backgroundColor="var(--ds-color-secondary-2-dark)"
+              backgroundColor="var(--ds-color-primary-2-dark)"
             />
           </div>
         )}
@@ -138,7 +138,7 @@ const Home = () => {
               title={t('want-to-see-interesting-content-title')}
               content={t('want-to-see-interesting-content-content')}
               buttonText={t('want-to-see-interesting-content-button')}
-              backgroundColor="var(--ds-color-secondary-2-dark)"
+              backgroundColor="var(--ds-color-primary-2-dark)"
             />
           </div>
         ) : (

--- a/src/routes/Search/Search.tsx
+++ b/src/routes/Search/Search.tsx
@@ -92,7 +92,7 @@ const Search = () => {
         </p>
         <form id="search" className="mb-7" onSubmit={handleSearch} noValidate data-testid="search-form">
           <div className="flex flex-row items-center">
-            <div className="flex w-full items-center rounded-md border border-border-form bg-white p-2 text-primary-gray">
+            <div className="border-border-form flex w-full items-center rounded-md border bg-white p-2 text-primary-gray">
               <input
                 type="text"
                 name="search"
@@ -126,7 +126,7 @@ const Search = () => {
             </div>
           </div>
           {submitError && (
-            <div className="mt-2 block font-arial text-form-error text-alert-text-2" role="alert">
+            <div className="mt-2 block font-arial text-form-error text-alert-2" role="alert">
               {submitError}
             </div>
           )}


### PR DESCRIPTION
<!--
PR checklist for developers:
- Have you ran tests and they pass?
- Did builds complete successfully?
- Remembered to run linters?

a11y:
- Sufficient color contrast for text and UI elements (https://webaim.org/resources/contrastchecker/)
- All interactive elements are accessible via keyboard navigation
- All images and icons have appropriate alt-text or aria-labels
- Headings are used in a logical order (h1, h2, h3...)
- Forms have associated labels and clear error messages
- No keyboard traps (user can navigate away from all elements)
- Focus indicators are visible for interactive elements
- Dynamic content updates are announced to assistive technologies
- Check the console for AXE linter issues
-->

## Description
‼️ **Requires** Opetushallitus/jod-design-system/pull/584

- Update `@jod/design-system`
- Update color tokens usage


<!-- Give some description about the PR.
- What was done and why? Give some context to help the reviewer.
- Where to focus especially?
-->

## Related JIRA ticket

<!-- Remember to add link to the JIRA issue
https://jira.eduuni.fi/browse/OPHJOD-XXX
-->

https://jira.eduuni.fi/browse/OPHJOD-2133
